### PR TITLE
Discord token env variable hotfix

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -58,5 +58,5 @@ client.once(Events.ClientReady, () => {
 	});
 });
 
-const token = process.env.token;
+const token = process.env.DISCORDTOKEN;
 client.login(token);


### PR DESCRIPTION
- Changed the name of Discord token env variable to be consistent with README.md